### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/CivicTechTO/councilspeak-matchmaking.png?label=ready&title=Ready)](https://waffle.io/CivicTechTO/councilspeak-matchmaking)
 # CouncilSpeak Matchmaking
 
 This platform aspires to connect citizens who want to speak


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/CivicTechTO/councilspeak-matchmaking

This was requested by a real person (user patcon) on waffle.io, we're not trying to spam you.
